### PR TITLE
Provide timeout for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ PLAUSIBLE_BASE_URL = "https://plausible.io"
 # of your site that may become available under the same name.
 
 PLAUSIBLE_SCRIPT_PREFIX = "plsbl/js"
+
+# Optionally, provide a timeout for the connection to your plausible endpoint in
+# seconds. Defaults to 1 second. Adjust to lower values in case you can't trust your
+# infrastructure to consistently deliver low load times and you don't care as much
+# about consistent analytics.
+PLAUSIBLE_REQUEST_TIMEOUT = 1
 ```
 
 Update `urls.py`.

--- a/plausible_proxy/views.py
+++ b/plausible_proxy/views.py
@@ -9,6 +9,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from plausible_proxy.services import (
     EVENT_HEADERS,
+    REQUEST_TIMEOUT,
     get_plausible_event_api_endpoint,
     get_script,
     get_user_agent,
@@ -21,6 +22,8 @@ def script_proxy(request: HttpRequest, script_name: str):
         script_bytes, script_headers = get_script(script_name)
     except ValueError:
         return HttpResponseNotFound("Not Found")
+    except requests.Timeout:
+        return HttpResponse(status=504)
     except requests.HTTPError:
         return HttpResponseServerError("Internal Server Error")
     return HttpResponse(content=script_bytes, headers=script_headers)
@@ -28,15 +31,20 @@ def script_proxy(request: HttpRequest, script_name: str):
 
 @csrf_exempt
 def event_proxy(request: HttpRequest):
-    resp = requests.post(
-        get_plausible_event_api_endpoint(),
-        data=request.body,
-        headers={
-            "content-type": "application/json",
-            "x-forwarded-for": get_xff(request),
-            "user-agent": get_user_agent(request),
-        },
-    )
+    try:
+        resp = requests.post(
+            get_plausible_event_api_endpoint(),
+            data=request.body,
+            headers={
+                "content-type": "application/json",
+                "x-forwarded-for": get_xff(request),
+                "user-agent": get_user_agent(request),
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+    except requests.Timeout:
+        return HttpResponse(status=504)
+
     return HttpResponse(
         content=resp.content,
         status=resp.status_code,


### PR DESCRIPTION
The requests api does not provide a default timeout. In synchronous setups this might cause problems, if for some reason the chosen plausible server does not respond.

I added a timeout to all proxied requests, not sure about the default of 1 sec though.