### PR TITLE
Render the {% plausible %} templatetag without the request object

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 
 - Drop support for Python 3.7.
 - Make it possible to call send_custom_event() with explicit remote_addr.
+- Make it possible to render the {% plausible %} templatetag without the request object, when PLAUSIBLE_DOMAIN is set
+  in settings. Thanks @hendi for the report. Ref #7.
 
 ## 0.4.0 (2023-03-30)
 

--- a/plausible_proxy/templatetags/plausible.py
+++ b/plausible_proxy/templatetags/plausible.py
@@ -1,9 +1,8 @@
 from django import template
+from django.conf import settings
 from django.forms.utils import flatatt
 from django.urls import reverse
 from django.utils.safestring import mark_safe
-
-from plausible_proxy.services import get_default_domain
 
 register = template.Library()
 
@@ -25,7 +24,14 @@ def plausible(context, domain=None, script="script.js"):
         `<script data-domain="example.com" src="/js/script.js" defer></script>`
     """
     if domain is None:
-        domain = get_default_domain(context["request"])
+        domain = getattr(settings, "PLAUSIBLE_DOMAIN", None)
+    if domain is None:
+        request = context.get("request")
+        if request is None:
+            raise ValueError(
+                "PLAUSIBLE_DOMAIN is not defined and request is not set in context."
+            )
+        domain = request.get_host()
     attrs = {
         "defer": True,
         "data-domain": domain,

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -23,6 +23,23 @@ def test_plausible_uses_plausible_domain_if_defined(rf, settings):
     )
 
 
+def test_plausible_uses_plausible_domain_if_request_not_defined(rf, settings):
+    settings.PLAUSIBLE_DOMAIN = "example2.com"
+    template = Template("{% load plausible %}{% plausible %}")
+    context = Context()
+    assert (
+        template.render(context)
+        == '<script data-domain="example2.com" src="/js/script.js" defer></script>'
+    )
+
+
+def test_plausible_raises_exception_if_domain_not_defined_anywhere(rf, settings):
+    template = Template("{% load plausible %}{% plausible %}")
+    context = Context()
+    with pytest.raises(ValueError):
+        template.render(context)
+
+
 @pytest.mark.skip(
     "Test fails as urlconf and urls.py content is cached. "
     "Still, the test works in isolation"


### PR DESCRIPTION
When settings.PLAUSIBLE_DOMAIN is srt, don't check if request is provided

Closes #7.